### PR TITLE
mm: memcontrol: allow swappiness above 100

### DIFF
--- a/mm/memcontrol.c
+++ b/mm/memcontrol.c
@@ -3551,7 +3551,7 @@ static int mem_cgroup_swappiness_write(struct cgroup_subsys_state *css,
 {
 	struct mem_cgroup *memcg = mem_cgroup_from_css(css);
 
-	if (val > 100)
+	if (val > 200)
 		return -EINVAL;
 
 	if (css->parent)


### PR DESCRIPTION
mm: memcontrol: allow swappiness above 100
Allow swappiness > 100, to prefer swapping over file reclaim. This is beneficial for use cases with fast swap devices like zram. Limit the swappiness to <= 200 to avoid an unsigned underflow in shrink_lruvec, and restrict to non-root cgroups.

CRs-Fixed: 988758
Change-Id: I4212590a6fad6fdbeb6664e42aa10f7ec1ce961d